### PR TITLE
Fix music path and duplicate function

### DIFF
--- a/Country_Info.py
+++ b/Country_Info.py
@@ -176,6 +176,3 @@ class CountryInfoApp(QWidget):
         except Exception as e:
             self.infoDisplay.append(f"\nFout bij het weergeven van de kaart: {str(e)}")
 
-def get_translated_country_name(self):
-    countryNameDutch = self.countryInput.text()
-    return self.country_map.get_country_name(countryNameDutch)

--- a/muziek.py
+++ b/muziek.py
@@ -9,10 +9,17 @@ import pygame
 pygame.mixer.init()
 
 # De map waarin de muziekbestanden staan
-muziek_map = r"C:\Users\maded\PycharmProjects\EdwinsEpicGame\Muziek"
+muziek_map = os.path.join(os.path.dirname(__file__), "Muziek")
 
 # Een lijst maken van alle muziekbestanden in de opgegeven map
-muziek_bestanden = [os.path.join(muziek_map, bestand) for bestand in os.listdir(muziek_map) if bestand.endswith('.mp3') or bestand.endswith('.wav')]
+if os.path.isdir(muziek_map):
+    muziek_bestanden = [
+        os.path.join(muziek_map, bestand)
+        for bestand in os.listdir(muziek_map)
+        if bestand.lower().endswith((".mp3", ".wav"))
+    ]
+else:
+    muziek_bestanden = []
 
 # Controleer of er muziekbestanden zijn gevonden
 if not muziek_bestanden:


### PR DESCRIPTION
## Summary
- use repository relative path for music files
- remove stray duplicate `get_translated_country_name` from `Country_Info`

## Testing
- `python -m py_compile Country_Info.py muziek.py`
- `python -m py_compile *.py`