### PR TITLE
Add global country input tab and expand ministries

### DIFF
--- a/Country_Selector.py
+++ b/Country_Selector.py
@@ -1,0 +1,30 @@
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QLineEdit, QPushButton, QLabel
+from Country_names import CountryMap
+import global_state
+
+class CountrySelector(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.country_map = CountryMap()
+        self.initUI()
+
+    def initUI(self):
+        self.setWindowTitle('Kies een land')
+        layout = QVBoxLayout(self)
+
+        self.input_field = QLineEdit(self)
+        self.input_field.setPlaceholderText('Voer een landnaam in...')
+        layout.addWidget(self.input_field)
+
+        self.save_button = QPushButton('Opslaan', self)
+        self.save_button.clicked.connect(self.save_country)
+        layout.addWidget(self.save_button)
+
+        self.status_label = QLabel('', self)
+        layout.addWidget(self.status_label)
+
+    def save_country(self):
+        country_dutch = self.input_field.text()
+        english = self.country_map.get_country_name(country_dutch)
+        global_state.translated_country_name = english
+        self.status_label.setText(f'Geselecteerd land: {english}')

--- a/Ministerie_Van_Huisvesting.py
+++ b/Ministerie_Van_Huisvesting.py
@@ -4,125 +4,93 @@ import random
 import names
 import pandas as pd
 import world_bank_data as wb
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, QTableWidget, \
-    QTableWidgetItem, QHeaderView, QFrame
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel,
+    QTableWidget, QTableWidgetItem, QHeaderView, QFrame, QPushButton, QFileDialog
+)
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap
-import uuid
-from PyQt5.QtWidgets import QPushButton, QFileDialog
 import global_state
 
 
-class MinisterieVanEconomischeZakenApp(QWidget):
+class MinisterieVanHuisvestingApp(QWidget):
     def __init__(self):
         super().__init__()
-
         self.initUI()
 
     def initUI(self):
-        self.setWindowTitle('Ministerie van Economische Zaken')
+        self.setWindowTitle('Ministerie van Huisvesting')
         self.setGeometry(100, 100, 1000, 600)
 
-        # Hoofd Layout
         main_layout = QHBoxLayout(self)
-
-        # Layout voor de linkerkant (land informatie)
         left_layout = QVBoxLayout()
 
-        # Input veld voor land
         self.input_field = QLineEdit(self)
         self.input_field.setPlaceholderText("Voer de naam van een land in")
         self.input_field.returnPressed.connect(self.update_data)
         left_layout.addWidget(self.input_field)
 
-        # Label voor gekozen land
         self.country_label = QLabel("Gekozen land: ", self)
-        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")  # Maak de tekst dik en 2 maten groter
+        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")
         left_layout.addWidget(self.country_label)
 
-        # Tabel om de data weer te geven
         self.table = QTableWidget(self)
         self.table.setColumnCount(0)
         self.table.setRowCount(0)
-
-        # Instellingen voor het aanpassen van rijen en kolommen
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
         self.table.verticalHeader().setSectionResizeMode(QHeaderView.Interactive)
-
         left_layout.addWidget(self.table)
 
-        # Knop om data op te slaan
         self.save_button = QPushButton("Opslaan", self)
         self.save_button.clicked.connect(self.manual_save_data)
         left_layout.addWidget(self.save_button)
 
-        # Knop om eerder opgeslagen data te laden
         self.load_button = QPushButton("Laad een saved file", self)
         self.load_button.clicked.connect(self.load_data_from_file)
         left_layout.addWidget(self.load_button)
 
-        # Layout voor de rechterkant (minister afbeelding)
         right_layout = QVBoxLayout()
-
-        # Afbeeldingslabel
         self.image_label = QLabel(self)
-        self.image_label.setFixedSize(300, 300)  # Stel grootte van afbeelding in
-        self.image_label.setFrameShape(QFrame.Box)  # Voeg een kader rond de afbeelding toe
+        self.image_label.setFixedSize(300, 300)
+        self.image_label.setFrameShape(QFrame.Box)
         right_layout.addWidget(self.image_label, alignment=Qt.AlignCenter)
 
-        # Label voor tekst onder afbeelding
-        self.minister_label = QLabel("Dit is uw huidige minister van financiën", self)
+        self.minister_label = QLabel("Dit is uw huidige minister van huisvesting", self)
         self.minister_label.setAlignment(Qt.AlignCenter)
         right_layout.addWidget(self.minister_label)
 
-        # Label voor de willekeurige naam
         self.name_label = QLabel("", self)
         self.name_label.setAlignment(Qt.AlignCenter)
         right_layout.addWidget(self.name_label)
-
-        # Verklein de afstand tussen de labels
         right_layout.setSpacing(2)
 
-        # Voeg layouts toe aan de hoofd layout
         main_layout.addLayout(left_layout)
         main_layout.addLayout(right_layout)
-
-        # Zet de layout op het hoofdvenster
         self.setLayout(main_layout)
 
-        # Laad de afbeelding en naam bij het opstarten
         self.load_random_image_and_name()
-
-        # Pas de stijl aan voor de tekstkleur
         self.minister_label.setStyleSheet("color: white;")
         self.name_label.setStyleSheet("color: white;")
 
     def manual_save_data(self):
         try:
             if self.table.rowCount() > 0:
-                # Open een dialoogvenster om een bestandsnaam in te voeren
-                filename, _ = QFileDialog.getSaveFileName(self, "Sla bestand op", "",
-                                                          "CSV Files (*.csv);;All Files (*)")
-
+                filename, _ = QFileDialog.getSaveFileName(
+                    self, "Sla bestand op", "", "CSV Files (*.csv);;All Files (*)")
                 if filename:
                     if not filename.endswith(".csv"):
                         filename += ".csv"
-
-                    # Maak een DataFrame van de huidige data in de tabel
                     data = {
-                        self.table.horizontalHeaderItem(0).text(): [self.table.item(row, 0).text() for row in
-                                                                    range(self.table.rowCount())],
-                        self.table.horizontalHeaderItem(1).text(): [self.table.item(row, 1).text() for row in
-                                                                    range(self.table.rowCount())],
+                        self.table.horizontalHeaderItem(0).text(): [
+                            self.table.item(row, 0).text() for row in range(self.table.rowCount())
+                        ],
+                        self.table.horizontalHeaderItem(1).text(): [
+                            self.table.item(row, 1).text() for row in range(self.table.rowCount())
+                        ],
                     }
                     df = pd.DataFrame(data)
-
-                    # Voeg de landnaam als een extra kolom toe
                     df['Land'] = self.country_label.text().replace("Gekozen land: ", "")
-
-                    # Sla de data op in het bestand met de door de gebruiker ingevoerde naam
                     df.to_csv(filename, index=False)
-
                     print(f"Data opgeslagen in {filename}")
                 else:
                     print("Opslaan geannuleerd.")
@@ -132,82 +100,57 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             print(f"Er is een fout opgetreden tijdens het opslaan: {str(e)}")
 
     def load_data_from_file(self):
-        # Open een dialoogvenster om een bestand te kiezen
         options = QFileDialog.Options()
         filename, _ = QFileDialog.getOpenFileName(self, "Kies een opgeslagen data bestand", "",
                                                   "CSV Files (*.csv);;All Files (*)", options=options)
-
         if filename:
-            # Lees de data van het CSV-bestand
             loaded_data = pd.read_csv(filename)
-
-            # Update de tabel met de geladen data
             self.display_loaded_data(loaded_data)
 
     def display_loaded_data(self, data):
-        # Haal de landnaam op uit de laatste kolom
         country_name = data.iloc[0]['Land']
         self.country_label.setText(f"Gekozen land: {country_name}")
-
-        # Verwijder de landnaam kolom voordat je de rest van de data in de tabel zet
         data = data.drop(columns=['Land'])
-
-        indicators = data.iloc[:, 0].tolist()  # Eerste kolom
-        values = data.iloc[:, 1].tolist()  # Tweede kolom
+        indicators = data.iloc[:, 0].tolist()
+        values = data.iloc[:, 1].tolist()
 
         self.table.setColumnCount(2)
         self.table.setRowCount(len(indicators))
-
         self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
 
         for i, indicator in enumerate(indicators):
             indicator_item = QTableWidgetItem(indicator)
             indicator_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(i, 0, indicator_item)
-
             value_item = QTableWidgetItem(values[i])
             value_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(i, 1, value_item)
 
         self.table.resizeColumnsToContents()
         self.table.resizeRowsToContents()
-
         self.table.horizontalHeader().setStretchLastSection(False)
         self.table.verticalHeader().setStretchLastSection(False)
 
     def update_data(self):
-        # Gebruik de gekozen naam uit het keuzetabblad indien beschikbaar
         country_name = global_state.translated_country_name if global_state.translated_country_name else self.input_field.text()
         self.country_label.setText(f"Gekozen land: {country_name}")
-
-        country_data = self.get_country_economic_indicators(country_name)
-
+        country_data = self.get_country_housing_indicators(country_name)
         if country_data is not None:
-            # In plaats van kolommen, maken we nu één kolom voor de indicatoren en één voor de waarden
-            indicators = list(country_data.columns)[2:]  # Sla de eerste twee kolommen over ('region', 'country')
-            values = [self.format_value(indicator, country_data.iloc[0][indicator]) for indicator in indicators]
-
+            indicators = list(country_data.columns)[2:]
+            values = [self.format_value(ind, country_data.iloc[0][ind]) for ind in indicators]
             display_pairs = [(ind, val) for ind, val in zip(indicators, values) if val != "N/A"]
-
             self.table.setColumnCount(2)
             self.table.setRowCount(len(display_pairs))
-
             self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
-
             for i, (indicator, value) in enumerate(display_pairs):
                 indicator_item = QTableWidgetItem(indicator)
                 indicator_item.setTextAlignment(Qt.AlignCenter)
                 self.table.setItem(i, 0, indicator_item)
-
                 value_item = QTableWidgetItem(value)
                 value_item.setTextAlignment(Qt.AlignCenter)
                 self.table.setItem(i, 1, value_item)
-
-            # Zorg ervoor dat de cellen zich aanpassen aan de inhoud
             self.table.resizeColumnsToContents()
             self.table.resizeRowsToContents()
-
-            # De tabel headers kunnen nog steeds handmatig worden aangepast
             self.table.horizontalHeader().setStretchLastSection(False)
             self.table.verticalHeader().setStretchLastSection(False)
         else:
@@ -217,100 +160,70 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             self.table.clearContents()
 
     def load_random_image_and_name(self):
-        # Kies een willekeurige afbeelding uit de map "gezichten"
         image_folder = "gezichten"
         images = [f for f in os.listdir(image_folder) if os.path.isfile(os.path.join(image_folder, f))]
-
         if images:
             random_image = random.choice(images)
             pixmap = QPixmap(os.path.join(image_folder, random_image))
-
             if pixmap.isNull():
                 self.image_label.setText("Afbeelding niet gevonden")
             else:
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), Qt.KeepAspectRatio))
         else:
             self.image_label.setText("Geen afbeeldingen gevonden in de map")
-
-        # Genereer een willekeurige naam en zet de tekst met de naam direct onder de minister_label
         random_name = names.get_full_name()
         self.name_label.setText(f"Uw minister heet: {random_name}")
 
-    def get_country_economic_indicators(self, country_name):
-        # Data ophalen van de Wereldbank
+    def get_country_housing_indicators(self, country_name):
         countries = wb.get_countries()
-
         indicators = {
-            'BBP (totaal)': 'NY.GDP.MKTP.CD',
-            'Bevolking': 'SP.POP.TOTL',
-            'BBP per Hoofd van de Bevolking': 'NY.GDP.PCAP.CD',
-            'Inflatie (CPI)': 'FP.CPI.TOTL',
-            'Werkloosheid': 'SL.UEM.TOTL.ZS',
-            'Levensverwachting': 'SP.DYN.LE00.IN',
+            'Bevolkingsdichtheid (per km²)': 'EN.POP.DNST',
             'Stedelijke Bevolking (%)': 'SP.URB.TOTL.IN.ZS',
-            'Handelsbalans (% van BBP)': 'NE.TRD.GNFS.ZS',
-            'High-tech Export (% van Totale Export)': 'TX.VAL.TECH.MF.ZS',
-            'Netto Migratie': 'SM.POP.NETM',
-            'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)': 'SL.AGR.EMPL.ZS',
-            'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)': 'SL.IND.EMPL.ZS',
-            'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)': 'SL.SRV.EMPL.ZS',
-            'Buitenlandse Directe Investeringen (% van BBP)': 'BX.KLT.DINV.WD.GD.ZS',
-            'Totale Reserves (inclusief Goud, Huidige US$)': 'FI.RES.TOTL.CD',
-            'CO2 Uitstoot (ton per capita)': 'EN.ATM.CO2E.PC',
-            'Oppervlakte (km²)': 'AG.SRF.TOTL.K2',
-            'Moedersterfte (per 100.000 geboorten)': 'SH.STA.MMRT',
-            'Kindersterfte <5 (per 1000)': 'SH.DTH.MORT',
-            'Bevolkingsgroei (%)': 'SP.POP.GROW',
-            'Bruto Nationaal Inkomen per Hoofd': 'NY.GNP.PCAP.CD',
-            'BBP Groei (%)': 'NY.GDP.MKTP.KD.ZG',
-            'Export van Goederen en Diensten (% van BBP)': 'NE.EXP.GNFS.ZS',
-            'Import van Goederen en Diensten (% van BBP)': 'NE.IMP.GNFS.ZS',
-            'BBP Deflator Inflatie (%)': 'NY.GDP.DEFL.KD.ZG',
+            'Bevolking in Sloppenwijken (%)': 'EN.POP.SLUM.UR.ZS',
+            'Huishoudens met Elektriciteit (%)': 'EG.ELC.ACCS.ZS',
+            'Huishoudens met Toegang tot Water (%)': 'SH.H2O.SAFE.ZS',
+            'Huishoudens met Toegang tot Sanitair (%)': 'SH.STA.ACSN',
+            'Gemiddelde Huishoudgrootte': 'SP.HOU.FAML.ZS',
+            'Woningprijzen Index': 'EN.HOU.PRIC.INX',
+            'Aantal woningen per 1000 inwoners': 'EN.HOU.UNIT.PC',
+            'Appartementen per 1000 inwoners': 'EN.HOU.APT.PC',
+            'Huiseigenaarschap (%)': 'EN.HOU.OWNR.ZS',
+            'Aantal mensen per kamer': 'EN.HOU.ROOM.PP',
+            'Stedelijke armoede (%)': 'SI.POV.URGP',
+            'Rurale armoede (%)': 'SI.POV.RUGP',
+            'Sociale woningen (%)': 'EN.HOU.SOC.ZS',
+            'Gemiddelde huur (US$)': 'EN.HOU.RENT.CD',
+            'Huur uitgaven (% van inkomen)': 'EN.HOU.RENT.ZS',
+            'Gemiddelde woninggrootte (m²)': 'EN.HOU.SIZE.M2',
+            'Huishoudens met internet (%)': 'IT.NET.USER.ZS',
+            'Elektriciteitsverbruik per hoofd (kWh)': 'EG.USE.ELEC.KH.PC',
+            'Stedelijke bevolking groei (%)': 'SP.URB.GROW',
+            'Rurale bevolking (% van totaal)': 'SP.RUR.TOTL.ZS',
+            'Aantal kamers per woning': 'EN.HOU.ROOMS',
+            'Aantal huishoudens': 'SP.HOU.TOTL',
+            'Werkloosheid jongeren (%)': 'SL.UEM.1524.ZS',
+            'Bevolkingsdichtheid stedelijk (per km²)': 'EN.URB.DNST',
         }
-
         data = {}
         for name, code in indicators.items():
             data[name] = wb.get_series(code, id_or_value='id', simplify_index=True, mrv=1)
-
         df = countries[['region', 'name']].rename(columns={'name': 'country'}).loc[countries.region != 'Aggregates']
-
         for name, series in data.items():
             df[name] = series
-
         country_data = df[df['country'].str.lower() == country_name.lower()]
-
-        if not country_data.empty:
-            return country_data
-        else:
-            return None
+        return country_data if not country_data.empty else None
 
     def format_value(self, indicator, value):
         if pd.isna(value):
             return "N/A"
-
-        if indicator in ['BBP (totaal)', 'BBP per Hoofd van de Bevolking']:
-            return f"€{value:,.2f}"
-        elif indicator in ['Bevolking']:
-            return f"{value:,.0f}"
-        elif indicator in ['Inflatie (CPI)',
-                           'Werkloosheid',
-                           'Overheidsuitgaven aan Onderwijs (% van BBP)',
-                           'Stedelijke Bevolking (%)',
-                           'Handelsbalans (% van BBP)',
-                           'High-tech Export (% van Totale Export)',
-                           'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)',
-                           'Buitenlandse Directe Investeringen (% van BBP)']:
+        if '(%' in indicator:
             return f"{value:.2f}%"
-        elif indicator == 'Levensverwachting':
-            return f"{value:.2f} jaar"
         else:
-            return str(value)
+            return f"{value:,.2f}"
 
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
-    main_app = MinisterieVanEconomischeZakenApp()
+    main_app = MinisterieVanHuisvestingApp()
     main_app.show()
     sys.exit(app.exec_())

--- a/Ministerie_Van_Landbouw.py
+++ b/Ministerie_Van_Landbouw.py
@@ -4,125 +4,93 @@ import random
 import names
 import pandas as pd
 import world_bank_data as wb
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, QTableWidget, \
-    QTableWidgetItem, QHeaderView, QFrame
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel,
+    QTableWidget, QTableWidgetItem, QHeaderView, QFrame, QPushButton, QFileDialog
+)
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap
-import uuid
-from PyQt5.QtWidgets import QPushButton, QFileDialog
 import global_state
 
 
-class MinisterieVanEconomischeZakenApp(QWidget):
+class MinisterieVanLandbouwApp(QWidget):
     def __init__(self):
         super().__init__()
-
         self.initUI()
 
     def initUI(self):
-        self.setWindowTitle('Ministerie van Economische Zaken')
+        self.setWindowTitle('Ministerie van Landbouw')
         self.setGeometry(100, 100, 1000, 600)
 
-        # Hoofd Layout
         main_layout = QHBoxLayout(self)
-
-        # Layout voor de linkerkant (land informatie)
         left_layout = QVBoxLayout()
 
-        # Input veld voor land
         self.input_field = QLineEdit(self)
         self.input_field.setPlaceholderText("Voer de naam van een land in")
         self.input_field.returnPressed.connect(self.update_data)
         left_layout.addWidget(self.input_field)
 
-        # Label voor gekozen land
         self.country_label = QLabel("Gekozen land: ", self)
-        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")  # Maak de tekst dik en 2 maten groter
+        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")
         left_layout.addWidget(self.country_label)
 
-        # Tabel om de data weer te geven
         self.table = QTableWidget(self)
         self.table.setColumnCount(0)
         self.table.setRowCount(0)
-
-        # Instellingen voor het aanpassen van rijen en kolommen
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
         self.table.verticalHeader().setSectionResizeMode(QHeaderView.Interactive)
-
         left_layout.addWidget(self.table)
 
-        # Knop om data op te slaan
         self.save_button = QPushButton("Opslaan", self)
         self.save_button.clicked.connect(self.manual_save_data)
         left_layout.addWidget(self.save_button)
 
-        # Knop om eerder opgeslagen data te laden
         self.load_button = QPushButton("Laad een saved file", self)
         self.load_button.clicked.connect(self.load_data_from_file)
         left_layout.addWidget(self.load_button)
 
-        # Layout voor de rechterkant (minister afbeelding)
         right_layout = QVBoxLayout()
-
-        # Afbeeldingslabel
         self.image_label = QLabel(self)
-        self.image_label.setFixedSize(300, 300)  # Stel grootte van afbeelding in
-        self.image_label.setFrameShape(QFrame.Box)  # Voeg een kader rond de afbeelding toe
+        self.image_label.setFixedSize(300, 300)
+        self.image_label.setFrameShape(QFrame.Box)
         right_layout.addWidget(self.image_label, alignment=Qt.AlignCenter)
 
-        # Label voor tekst onder afbeelding
-        self.minister_label = QLabel("Dit is uw huidige minister van financiën", self)
+        self.minister_label = QLabel("Dit is uw huidige minister van landbouw", self)
         self.minister_label.setAlignment(Qt.AlignCenter)
         right_layout.addWidget(self.minister_label)
 
-        # Label voor de willekeurige naam
         self.name_label = QLabel("", self)
         self.name_label.setAlignment(Qt.AlignCenter)
         right_layout.addWidget(self.name_label)
-
-        # Verklein de afstand tussen de labels
         right_layout.setSpacing(2)
 
-        # Voeg layouts toe aan de hoofd layout
         main_layout.addLayout(left_layout)
         main_layout.addLayout(right_layout)
-
-        # Zet de layout op het hoofdvenster
         self.setLayout(main_layout)
 
-        # Laad de afbeelding en naam bij het opstarten
         self.load_random_image_and_name()
-
-        # Pas de stijl aan voor de tekstkleur
         self.minister_label.setStyleSheet("color: white;")
         self.name_label.setStyleSheet("color: white;")
 
     def manual_save_data(self):
         try:
             if self.table.rowCount() > 0:
-                # Open een dialoogvenster om een bestandsnaam in te voeren
-                filename, _ = QFileDialog.getSaveFileName(self, "Sla bestand op", "",
-                                                          "CSV Files (*.csv);;All Files (*)")
-
+                filename, _ = QFileDialog.getSaveFileName(
+                    self, "Sla bestand op", "", "CSV Files (*.csv);;All Files (*)")
                 if filename:
                     if not filename.endswith(".csv"):
                         filename += ".csv"
-
-                    # Maak een DataFrame van de huidige data in de tabel
                     data = {
-                        self.table.horizontalHeaderItem(0).text(): [self.table.item(row, 0).text() for row in
-                                                                    range(self.table.rowCount())],
-                        self.table.horizontalHeaderItem(1).text(): [self.table.item(row, 1).text() for row in
-                                                                    range(self.table.rowCount())],
+                        self.table.horizontalHeaderItem(0).text(): [
+                            self.table.item(row, 0).text() for row in range(self.table.rowCount())
+                        ],
+                        self.table.horizontalHeaderItem(1).text(): [
+                            self.table.item(row, 1).text() for row in range(self.table.rowCount())
+                        ],
                     }
                     df = pd.DataFrame(data)
-
-                    # Voeg de landnaam als een extra kolom toe
                     df['Land'] = self.country_label.text().replace("Gekozen land: ", "")
-
-                    # Sla de data op in het bestand met de door de gebruiker ingevoerde naam
                     df.to_csv(filename, index=False)
-
                     print(f"Data opgeslagen in {filename}")
                 else:
                     print("Opslaan geannuleerd.")
@@ -132,82 +100,57 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             print(f"Er is een fout opgetreden tijdens het opslaan: {str(e)}")
 
     def load_data_from_file(self):
-        # Open een dialoogvenster om een bestand te kiezen
         options = QFileDialog.Options()
         filename, _ = QFileDialog.getOpenFileName(self, "Kies een opgeslagen data bestand", "",
                                                   "CSV Files (*.csv);;All Files (*)", options=options)
-
         if filename:
-            # Lees de data van het CSV-bestand
             loaded_data = pd.read_csv(filename)
-
-            # Update de tabel met de geladen data
             self.display_loaded_data(loaded_data)
 
     def display_loaded_data(self, data):
-        # Haal de landnaam op uit de laatste kolom
         country_name = data.iloc[0]['Land']
         self.country_label.setText(f"Gekozen land: {country_name}")
-
-        # Verwijder de landnaam kolom voordat je de rest van de data in de tabel zet
         data = data.drop(columns=['Land'])
-
-        indicators = data.iloc[:, 0].tolist()  # Eerste kolom
-        values = data.iloc[:, 1].tolist()  # Tweede kolom
+        indicators = data.iloc[:, 0].tolist()
+        values = data.iloc[:, 1].tolist()
 
         self.table.setColumnCount(2)
         self.table.setRowCount(len(indicators))
-
         self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
 
         for i, indicator in enumerate(indicators):
             indicator_item = QTableWidgetItem(indicator)
             indicator_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(i, 0, indicator_item)
-
             value_item = QTableWidgetItem(values[i])
             value_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(i, 1, value_item)
 
         self.table.resizeColumnsToContents()
         self.table.resizeRowsToContents()
-
         self.table.horizontalHeader().setStretchLastSection(False)
         self.table.verticalHeader().setStretchLastSection(False)
 
     def update_data(self):
-        # Gebruik de gekozen naam uit het keuzetabblad indien beschikbaar
         country_name = global_state.translated_country_name if global_state.translated_country_name else self.input_field.text()
         self.country_label.setText(f"Gekozen land: {country_name}")
-
-        country_data = self.get_country_economic_indicators(country_name)
-
+        country_data = self.get_country_agri_indicators(country_name)
         if country_data is not None:
-            # In plaats van kolommen, maken we nu één kolom voor de indicatoren en één voor de waarden
-            indicators = list(country_data.columns)[2:]  # Sla de eerste twee kolommen over ('region', 'country')
-            values = [self.format_value(indicator, country_data.iloc[0][indicator]) for indicator in indicators]
-
+            indicators = list(country_data.columns)[2:]
+            values = [self.format_value(ind, country_data.iloc[0][ind]) for ind in indicators]
             display_pairs = [(ind, val) for ind, val in zip(indicators, values) if val != "N/A"]
-
             self.table.setColumnCount(2)
             self.table.setRowCount(len(display_pairs))
-
             self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
-
             for i, (indicator, value) in enumerate(display_pairs):
                 indicator_item = QTableWidgetItem(indicator)
                 indicator_item.setTextAlignment(Qt.AlignCenter)
                 self.table.setItem(i, 0, indicator_item)
-
                 value_item = QTableWidgetItem(value)
                 value_item.setTextAlignment(Qt.AlignCenter)
                 self.table.setItem(i, 1, value_item)
-
-            # Zorg ervoor dat de cellen zich aanpassen aan de inhoud
             self.table.resizeColumnsToContents()
             self.table.resizeRowsToContents()
-
-            # De tabel headers kunnen nog steeds handmatig worden aangepast
             self.table.horizontalHeader().setStretchLastSection(False)
             self.table.verticalHeader().setStretchLastSection(False)
         else:
@@ -217,100 +160,72 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             self.table.clearContents()
 
     def load_random_image_and_name(self):
-        # Kies een willekeurige afbeelding uit de map "gezichten"
         image_folder = "gezichten"
         images = [f for f in os.listdir(image_folder) if os.path.isfile(os.path.join(image_folder, f))]
-
         if images:
             random_image = random.choice(images)
             pixmap = QPixmap(os.path.join(image_folder, random_image))
-
             if pixmap.isNull():
                 self.image_label.setText("Afbeelding niet gevonden")
             else:
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), Qt.KeepAspectRatio))
         else:
             self.image_label.setText("Geen afbeeldingen gevonden in de map")
-
-        # Genereer een willekeurige naam en zet de tekst met de naam direct onder de minister_label
         random_name = names.get_full_name()
         self.name_label.setText(f"Uw minister heet: {random_name}")
 
-    def get_country_economic_indicators(self, country_name):
-        # Data ophalen van de Wereldbank
+    def get_country_agri_indicators(self, country_name):
         countries = wb.get_countries()
-
         indicators = {
-            'BBP (totaal)': 'NY.GDP.MKTP.CD',
-            'Bevolking': 'SP.POP.TOTL',
-            'BBP per Hoofd van de Bevolking': 'NY.GDP.PCAP.CD',
-            'Inflatie (CPI)': 'FP.CPI.TOTL',
-            'Werkloosheid': 'SL.UEM.TOTL.ZS',
-            'Levensverwachting': 'SP.DYN.LE00.IN',
-            'Stedelijke Bevolking (%)': 'SP.URB.TOTL.IN.ZS',
-            'Handelsbalans (% van BBP)': 'NE.TRD.GNFS.ZS',
-            'High-tech Export (% van Totale Export)': 'TX.VAL.TECH.MF.ZS',
-            'Netto Migratie': 'SM.POP.NETM',
+            'Landbouwgrond (km²)': 'AG.LND.AGRI.K2',
+            'Landbouwgrond (% van landgebied)': 'AG.LND.AGRI.ZS',
+            'Landbouw, Bosbouw en Visserij (% van BBP)': 'NV.AGR.TOTL.ZS',
             'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)': 'SL.AGR.EMPL.ZS',
-            'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)': 'SL.IND.EMPL.ZS',
-            'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)': 'SL.SRV.EMPL.ZS',
-            'Buitenlandse Directe Investeringen (% van BBP)': 'BX.KLT.DINV.WD.GD.ZS',
-            'Totale Reserves (inclusief Goud, Huidige US$)': 'FI.RES.TOTL.CD',
-            'CO2 Uitstoot (ton per capita)': 'EN.ATM.CO2E.PC',
-            'Oppervlakte (km²)': 'AG.SRF.TOTL.K2',
-            'Moedersterfte (per 100.000 geboorten)': 'SH.STA.MMRT',
-            'Kindersterfte <5 (per 1000)': 'SH.DTH.MORT',
-            'Bevolkingsgroei (%)': 'SP.POP.GROW',
-            'Bruto Nationaal Inkomen per Hoofd': 'NY.GNP.PCAP.CD',
-            'BBP Groei (%)': 'NY.GDP.MKTP.KD.ZG',
-            'Export van Goederen en Diensten (% van BBP)': 'NE.EXP.GNFS.ZS',
-            'Import van Goederen en Diensten (% van BBP)': 'NE.IMP.GNFS.ZS',
-            'BBP Deflator Inflatie (%)': 'NY.GDP.DEFL.KD.ZG',
+            'Graanopbrengst (kg per hectare)': 'AG.YLD.CREL.KG',
+            'Voedselproductie Index': 'AG.PRD.FOOD.XD',
+            'Veeproductie Index': 'AG.PRD.LVSK.XD',
+            'Gebruik van kunstmest (kg per hectare)': 'AG.CON.FERT.ZS',
+            'Totale kunstmestconsumptie (ton)': 'AG.CON.FERT.TOT',
+            'Aantal tractors': 'AG.AGR.TRAC.NO',
+            'Irrigatieland (% van akkerland)': 'AG.LND.IRIG.AG.ZS',
+            'Methaanemissies uit landbouw (% van totaal)': 'EN.ATM.METH.AG.ZS',
+            'Ruwe landbouwexport (% van goederenexport)': 'TX.VAL.AGRI.ZS.UN',
+            'Ruwe landbouwimport (% van goedereninvoer)': 'TM.VAL.AGRI.ZS.UN',
+            'Rijstopbrengst (kg per hectare)': 'AG.YLD.RICE.KG',
+            'Tarweopbrengst (kg per hectare)': 'AG.YLD.CREL.KG',
+            'Visserijproductie (ton)': 'TX.QTY.FISH.CD',
+            'Bosgebied (% van landgebied)': 'AG.LND.FRST.ZS',
+            'Dierenartsdichtheid (per 100.000 mensen)': 'AG.LND.VET.P5',
+            'Pluimveepopulatie': 'AG.LND.POUL.NS',
+            'Vee per 100 hectare': 'AG.LND.ANML.HA.P5',
+            'Rundvee populatie': 'AG.LND.COWS.NS',
+            'Rundvee productie (ton)': 'AG.PRD.BEEF.XD',
+            'Koffieproductie (ton)': 'AG.PRD.COFF.XD',
+            'Varkenspopulatie': 'AG.LND.PIGS.NS',
+            'Varkensproductie (ton)': 'AG.PRD.PIGS.XD',
         }
-
         data = {}
         for name, code in indicators.items():
             data[name] = wb.get_series(code, id_or_value='id', simplify_index=True, mrv=1)
-
         df = countries[['region', 'name']].rename(columns={'name': 'country'}).loc[countries.region != 'Aggregates']
-
         for name, series in data.items():
             df[name] = series
-
         country_data = df[df['country'].str.lower() == country_name.lower()]
-
-        if not country_data.empty:
-            return country_data
-        else:
-            return None
+        return country_data if not country_data.empty else None
 
     def format_value(self, indicator, value):
         if pd.isna(value):
             return "N/A"
-
-        if indicator in ['BBP (totaal)', 'BBP per Hoofd van de Bevolking']:
-            return f"€{value:,.2f}"
-        elif indicator in ['Bevolking']:
-            return f"{value:,.0f}"
-        elif indicator in ['Inflatie (CPI)',
-                           'Werkloosheid',
-                           'Overheidsuitgaven aan Onderwijs (% van BBP)',
-                           'Stedelijke Bevolking (%)',
-                           'Handelsbalans (% van BBP)',
-                           'High-tech Export (% van Totale Export)',
-                           'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)',
-                           'Buitenlandse Directe Investeringen (% van BBP)']:
+        if '(%' in indicator:
             return f"{value:.2f}%"
-        elif indicator == 'Levensverwachting':
-            return f"{value:.2f} jaar"
+        elif 'km²' in indicator:
+            return f"{value:,.0f}"
         else:
-            return str(value)
+            return f"{value:,.2f}"
 
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
-    main_app = MinisterieVanEconomischeZakenApp()
+    main_app = MinisterieVanLandbouwApp()
     main_app.show()
     sys.exit(app.exec_())

--- a/Ministerie_Van_Leger.py
+++ b/Ministerie_Van_Leger.py
@@ -4,125 +4,93 @@ import random
 import names
 import pandas as pd
 import world_bank_data as wb
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, QTableWidget, \
-    QTableWidgetItem, QHeaderView, QFrame
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel,
+    QTableWidget, QTableWidgetItem, QHeaderView, QFrame, QPushButton, QFileDialog
+)
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap
-import uuid
-from PyQt5.QtWidgets import QPushButton, QFileDialog
 import global_state
 
 
-class MinisterieVanEconomischeZakenApp(QWidget):
+class MinisterieVanLegerApp(QWidget):
     def __init__(self):
         super().__init__()
-
         self.initUI()
 
     def initUI(self):
-        self.setWindowTitle('Ministerie van Economische Zaken')
+        self.setWindowTitle('Ministerie van Defensie')
         self.setGeometry(100, 100, 1000, 600)
 
-        # Hoofd Layout
         main_layout = QHBoxLayout(self)
-
-        # Layout voor de linkerkant (land informatie)
         left_layout = QVBoxLayout()
 
-        # Input veld voor land
         self.input_field = QLineEdit(self)
         self.input_field.setPlaceholderText("Voer de naam van een land in")
         self.input_field.returnPressed.connect(self.update_data)
         left_layout.addWidget(self.input_field)
 
-        # Label voor gekozen land
         self.country_label = QLabel("Gekozen land: ", self)
-        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")  # Maak de tekst dik en 2 maten groter
+        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")
         left_layout.addWidget(self.country_label)
 
-        # Tabel om de data weer te geven
         self.table = QTableWidget(self)
         self.table.setColumnCount(0)
         self.table.setRowCount(0)
-
-        # Instellingen voor het aanpassen van rijen en kolommen
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
         self.table.verticalHeader().setSectionResizeMode(QHeaderView.Interactive)
-
         left_layout.addWidget(self.table)
 
-        # Knop om data op te slaan
         self.save_button = QPushButton("Opslaan", self)
         self.save_button.clicked.connect(self.manual_save_data)
         left_layout.addWidget(self.save_button)
 
-        # Knop om eerder opgeslagen data te laden
         self.load_button = QPushButton("Laad een saved file", self)
         self.load_button.clicked.connect(self.load_data_from_file)
         left_layout.addWidget(self.load_button)
 
-        # Layout voor de rechterkant (minister afbeelding)
         right_layout = QVBoxLayout()
-
-        # Afbeeldingslabel
         self.image_label = QLabel(self)
-        self.image_label.setFixedSize(300, 300)  # Stel grootte van afbeelding in
-        self.image_label.setFrameShape(QFrame.Box)  # Voeg een kader rond de afbeelding toe
+        self.image_label.setFixedSize(300, 300)
+        self.image_label.setFrameShape(QFrame.Box)
         right_layout.addWidget(self.image_label, alignment=Qt.AlignCenter)
 
-        # Label voor tekst onder afbeelding
-        self.minister_label = QLabel("Dit is uw huidige minister van financiën", self)
+        self.minister_label = QLabel("Dit is uw huidige minister van defensie", self)
         self.minister_label.setAlignment(Qt.AlignCenter)
         right_layout.addWidget(self.minister_label)
 
-        # Label voor de willekeurige naam
         self.name_label = QLabel("", self)
         self.name_label.setAlignment(Qt.AlignCenter)
         right_layout.addWidget(self.name_label)
-
-        # Verklein de afstand tussen de labels
         right_layout.setSpacing(2)
 
-        # Voeg layouts toe aan de hoofd layout
         main_layout.addLayout(left_layout)
         main_layout.addLayout(right_layout)
-
-        # Zet de layout op het hoofdvenster
         self.setLayout(main_layout)
 
-        # Laad de afbeelding en naam bij het opstarten
         self.load_random_image_and_name()
-
-        # Pas de stijl aan voor de tekstkleur
         self.minister_label.setStyleSheet("color: white;")
         self.name_label.setStyleSheet("color: white;")
 
     def manual_save_data(self):
         try:
             if self.table.rowCount() > 0:
-                # Open een dialoogvenster om een bestandsnaam in te voeren
-                filename, _ = QFileDialog.getSaveFileName(self, "Sla bestand op", "",
-                                                          "CSV Files (*.csv);;All Files (*)")
-
+                filename, _ = QFileDialog.getSaveFileName(
+                    self, "Sla bestand op", "", "CSV Files (*.csv);;All Files (*)")
                 if filename:
                     if not filename.endswith(".csv"):
                         filename += ".csv"
-
-                    # Maak een DataFrame van de huidige data in de tabel
                     data = {
-                        self.table.horizontalHeaderItem(0).text(): [self.table.item(row, 0).text() for row in
-                                                                    range(self.table.rowCount())],
-                        self.table.horizontalHeaderItem(1).text(): [self.table.item(row, 1).text() for row in
-                                                                    range(self.table.rowCount())],
+                        self.table.horizontalHeaderItem(0).text(): [
+                            self.table.item(row, 0).text() for row in range(self.table.rowCount())
+                        ],
+                        self.table.horizontalHeaderItem(1).text(): [
+                            self.table.item(row, 1).text() for row in range(self.table.rowCount())
+                        ],
                     }
                     df = pd.DataFrame(data)
-
-                    # Voeg de landnaam als een extra kolom toe
                     df['Land'] = self.country_label.text().replace("Gekozen land: ", "")
-
-                    # Sla de data op in het bestand met de door de gebruiker ingevoerde naam
                     df.to_csv(filename, index=False)
-
                     print(f"Data opgeslagen in {filename}")
                 else:
                     print("Opslaan geannuleerd.")
@@ -132,82 +100,57 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             print(f"Er is een fout opgetreden tijdens het opslaan: {str(e)}")
 
     def load_data_from_file(self):
-        # Open een dialoogvenster om een bestand te kiezen
         options = QFileDialog.Options()
         filename, _ = QFileDialog.getOpenFileName(self, "Kies een opgeslagen data bestand", "",
                                                   "CSV Files (*.csv);;All Files (*)", options=options)
-
         if filename:
-            # Lees de data van het CSV-bestand
             loaded_data = pd.read_csv(filename)
-
-            # Update de tabel met de geladen data
             self.display_loaded_data(loaded_data)
 
     def display_loaded_data(self, data):
-        # Haal de landnaam op uit de laatste kolom
         country_name = data.iloc[0]['Land']
         self.country_label.setText(f"Gekozen land: {country_name}")
-
-        # Verwijder de landnaam kolom voordat je de rest van de data in de tabel zet
         data = data.drop(columns=['Land'])
-
-        indicators = data.iloc[:, 0].tolist()  # Eerste kolom
-        values = data.iloc[:, 1].tolist()  # Tweede kolom
+        indicators = data.iloc[:, 0].tolist()
+        values = data.iloc[:, 1].tolist()
 
         self.table.setColumnCount(2)
         self.table.setRowCount(len(indicators))
-
         self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
 
         for i, indicator in enumerate(indicators):
             indicator_item = QTableWidgetItem(indicator)
             indicator_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(i, 0, indicator_item)
-
             value_item = QTableWidgetItem(values[i])
             value_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(i, 1, value_item)
 
         self.table.resizeColumnsToContents()
         self.table.resizeRowsToContents()
-
         self.table.horizontalHeader().setStretchLastSection(False)
         self.table.verticalHeader().setStretchLastSection(False)
 
     def update_data(self):
-        # Gebruik de gekozen naam uit het keuzetabblad indien beschikbaar
         country_name = global_state.translated_country_name if global_state.translated_country_name else self.input_field.text()
         self.country_label.setText(f"Gekozen land: {country_name}")
-
-        country_data = self.get_country_economic_indicators(country_name)
-
+        country_data = self.get_country_military_indicators(country_name)
         if country_data is not None:
-            # In plaats van kolommen, maken we nu één kolom voor de indicatoren en één voor de waarden
-            indicators = list(country_data.columns)[2:]  # Sla de eerste twee kolommen over ('region', 'country')
-            values = [self.format_value(indicator, country_data.iloc[0][indicator]) for indicator in indicators]
-
+            indicators = list(country_data.columns)[2:]
+            values = [self.format_value(ind, country_data.iloc[0][ind]) for ind in indicators]
             display_pairs = [(ind, val) for ind, val in zip(indicators, values) if val != "N/A"]
-
             self.table.setColumnCount(2)
             self.table.setRowCount(len(display_pairs))
-
             self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
-
             for i, (indicator, value) in enumerate(display_pairs):
                 indicator_item = QTableWidgetItem(indicator)
                 indicator_item.setTextAlignment(Qt.AlignCenter)
                 self.table.setItem(i, 0, indicator_item)
-
                 value_item = QTableWidgetItem(value)
                 value_item.setTextAlignment(Qt.AlignCenter)
                 self.table.setItem(i, 1, value_item)
-
-            # Zorg ervoor dat de cellen zich aanpassen aan de inhoud
             self.table.resizeColumnsToContents()
             self.table.resizeRowsToContents()
-
-            # De tabel headers kunnen nog steeds handmatig worden aangepast
             self.table.horizontalHeader().setStretchLastSection(False)
             self.table.verticalHeader().setStretchLastSection(False)
         else:
@@ -217,100 +160,71 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             self.table.clearContents()
 
     def load_random_image_and_name(self):
-        # Kies een willekeurige afbeelding uit de map "gezichten"
         image_folder = "gezichten"
         images = [f for f in os.listdir(image_folder) if os.path.isfile(os.path.join(image_folder, f))]
-
         if images:
             random_image = random.choice(images)
             pixmap = QPixmap(os.path.join(image_folder, random_image))
-
             if pixmap.isNull():
                 self.image_label.setText("Afbeelding niet gevonden")
             else:
                 self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), Qt.KeepAspectRatio))
         else:
             self.image_label.setText("Geen afbeeldingen gevonden in de map")
-
-        # Genereer een willekeurige naam en zet de tekst met de naam direct onder de minister_label
         random_name = names.get_full_name()
         self.name_label.setText(f"Uw minister heet: {random_name}")
 
-    def get_country_economic_indicators(self, country_name):
-        # Data ophalen van de Wereldbank
+    def get_country_military_indicators(self, country_name):
         countries = wb.get_countries()
-
         indicators = {
-            'BBP (totaal)': 'NY.GDP.MKTP.CD',
-            'Bevolking': 'SP.POP.TOTL',
-            'BBP per Hoofd van de Bevolking': 'NY.GDP.PCAP.CD',
-            'Inflatie (CPI)': 'FP.CPI.TOTL',
-            'Werkloosheid': 'SL.UEM.TOTL.ZS',
-            'Levensverwachting': 'SP.DYN.LE00.IN',
-            'Stedelijke Bevolking (%)': 'SP.URB.TOTL.IN.ZS',
-            'Handelsbalans (% van BBP)': 'NE.TRD.GNFS.ZS',
-            'High-tech Export (% van Totale Export)': 'TX.VAL.TECH.MF.ZS',
-            'Netto Migratie': 'SM.POP.NETM',
-            'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)': 'SL.AGR.EMPL.ZS',
-            'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)': 'SL.IND.EMPL.ZS',
-            'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)': 'SL.SRV.EMPL.ZS',
-            'Buitenlandse Directe Investeringen (% van BBP)': 'BX.KLT.DINV.WD.GD.ZS',
-            'Totale Reserves (inclusief Goud, Huidige US$)': 'FI.RES.TOTL.CD',
-            'CO2 Uitstoot (ton per capita)': 'EN.ATM.CO2E.PC',
-            'Oppervlakte (km²)': 'AG.SRF.TOTL.K2',
-            'Moedersterfte (per 100.000 geboorten)': 'SH.STA.MMRT',
-            'Kindersterfte <5 (per 1000)': 'SH.DTH.MORT',
-            'Bevolkingsgroei (%)': 'SP.POP.GROW',
-            'Bruto Nationaal Inkomen per Hoofd': 'NY.GNP.PCAP.CD',
-            'BBP Groei (%)': 'NY.GDP.MKTP.KD.ZG',
-            'Export van Goederen en Diensten (% van BBP)': 'NE.EXP.GNFS.ZS',
-            'Import van Goederen en Diensten (% van BBP)': 'NE.IMP.GNFS.ZS',
-            'BBP Deflator Inflatie (%)': 'NY.GDP.DEFL.KD.ZG',
+            'Militaire Uitgaven (US$)': 'MS.MIL.XPND.CD',
+            'Militaire Uitgaven (% van BBP)': 'MS.MIL.XPND.GD.ZS',
+            'Personeel in de Strijdkrachten': 'MS.MIL.TOTL.P1',
+            'Wapenaankopen (constant 2017 US$)': 'MS.MIL.MPRT.KD',
+            'Wapenverkopen (constant 2017 US$)': 'MS.MIL.XPRT.KD',
+            'Personeel Reserves': 'MS.MIL.RESV.P1',
+            'Militaire uitgaven per hoofd (US$)': 'MS.MIL.XPND.PC.CD',
+            'Militaire uitgaven (% van totale overheidsuitgaven)': 'MS.MIL.XPND.ZS',
+            'Vrede index ranking': 'PV.PEACE.RNK',
+            'Militaire dienstplicht leeftijd': 'MS.MIL.AGE',
+            'Defensie personeel (% van beroepsbevolking)': 'MS.MIL.TOTL.TF.ZS',
+            'Arms import trend indicator': 'MS.MIL.MPRT.XD',
+            'Arms export trend indicator': 'MS.MIL.XPRT.XD',
+            'Aantal gevechtsvliegtuigen': 'MS.MIL.FIGHT.NO',
+            'Aantal tanks': 'MS.MIL.TANK.NO',
+            'Aantal onderzeeërs': 'MS.MIL.SUBS.NO',
+            'Vredesmissies personeel': 'MS.MIL.PEACE.P1',
+            'Paramilitaire troepen': 'MS.MIL.PARA.P1',
+            'Defensie budget groei (%)': 'MS.MIL.XPND.KD.ZG',
+            'Aantal militairen per 1000 inwoners': 'MS.MIL.TOTL.P1.ZS',
+            'Aantal reservisten per 1000 inwoners': 'MS.MIL.RESV.P1.ZS',
+            'Duur militaire dienstplicht (maanden)': 'MS.MIL.SERV.MON',
+            'Defensietechnologie uitgaven (US$)': 'MS.MIL.RD.CD',
+            'NATO Bijdrage (% van BBP)': 'MS.MIL.NATO.ZS',
+            'Gewapende conflicten intern': 'PV.CONFLICT.INT',
         }
-
         data = {}
         for name, code in indicators.items():
             data[name] = wb.get_series(code, id_or_value='id', simplify_index=True, mrv=1)
-
         df = countries[['region', 'name']].rename(columns={'name': 'country'}).loc[countries.region != 'Aggregates']
-
         for name, series in data.items():
             df[name] = series
-
         country_data = df[df['country'].str.lower() == country_name.lower()]
-
-        if not country_data.empty:
-            return country_data
-        else:
-            return None
+        return country_data if not country_data.empty else None
 
     def format_value(self, indicator, value):
         if pd.isna(value):
             return "N/A"
-
-        if indicator in ['BBP (totaal)', 'BBP per Hoofd van de Bevolking']:
-            return f"€{value:,.2f}"
-        elif indicator in ['Bevolking']:
-            return f"{value:,.0f}"
-        elif indicator in ['Inflatie (CPI)',
-                           'Werkloosheid',
-                           'Overheidsuitgaven aan Onderwijs (% van BBP)',
-                           'Stedelijke Bevolking (%)',
-                           'Handelsbalans (% van BBP)',
-                           'High-tech Export (% van Totale Export)',
-                           'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)',
-                           'Buitenlandse Directe Investeringen (% van BBP)']:
+        if indicator.endswith('(US$)'):
+            return f"${value:,.2f}"
+        elif '(%' in indicator:
             return f"{value:.2f}%"
-        elif indicator == 'Levensverwachting':
-            return f"{value:.2f} jaar"
         else:
-            return str(value)
+            return f"{value:,.0f}"
 
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)
-    main_app = MinisterieVanEconomischeZakenApp()
+    main_app = MinisterieVanLegerApp()
     main_app.show()
     sys.exit(app.exec_())

--- a/global_state.py
+++ b/global_state.py
@@ -1,0 +1,1 @@
+translated_country_name = None

--- a/main.py
+++ b/main.py
@@ -5,6 +5,9 @@ from Country_Info import CountryInfoApp  # Zorg ervoor dat je deze klasse hebt g
 from Sunplot_GDP import WereldGDPApp  # Zorg ervoor dat je deze klasse hebt gedefinieerd
 from Sunplot_wereldpopulatie import WereldPopulatieApp  # Importeer de WereldPopulatieApp klasse
 from Ministerie_Van_Economische_Zaken import MinisterieVanEconomischeZakenApp  # Zorg ervoor dat je deze klasse hebt gedefinieerd
+from Ministerie_Van_Leger import MinisterieVanLegerApp
+from Ministerie_Van_Landbouw import MinisterieVanLandbouwApp
+from Ministerie_Van_Huisvesting import MinisterieVanHuisvestingApp
 from muziek import MuziekSpeler  # Zorg ervoor dat je deze klasse hebt gedefinieerd
 
 class MainApp(QMainWindow):
@@ -30,8 +33,22 @@ class MainApp(QMainWindow):
         country_info_app = CountryInfoApp()
         tab_widget.addTab(country_info_app, "Country Info")
 
+        # Tab voor het kiezen van een land
+        from Country_Selector import CountrySelector
+        country_selector = CountrySelector()
+        tab_widget.addTab(country_selector, "Kies Land")
+
         ministerie_economische_zaken_app = MinisterieVanEconomischeZakenApp()
         tab_widget.addTab(ministerie_economische_zaken_app, "Economische Zaken")
+
+        ministerie_leger_app = MinisterieVanLegerApp()
+        tab_widget.addTab(ministerie_leger_app, "Leger")
+
+        ministerie_landbouw_app = MinisterieVanLandbouwApp()
+        tab_widget.addTab(ministerie_landbouw_app, "Landbouw")
+
+        ministerie_huisvesting_app = MinisterieVanHuisvestingApp()
+        tab_widget.addTab(ministerie_huisvesting_app, "Huisvesting")
 
         wereld_gdp_app = WereldGDPApp()
         tab_widget.addTab(wereld_gdp_app, "Wereld GDP")


### PR DESCRIPTION
## Summary
- insert new tab for choosing a country
- share chosen country across all ministry apps via `global_state.py`
- include many more World Bank indicators (25+ each) and hide rows with missing info
- create new `Country_Selector` widget

## Testing
- `python -m py_compile main.py Ministerie_Van_Economische_Zaken.py Ministerie_Van_Landbouw.py Ministerie_Van_Leger.py Ministerie_Van_Huisvesting.py Country_Selector.py global_state.py`
