### PR TITLE
Refactor ministeries with shared base class

### DIFF
--- a/Ministerie_Base.py
+++ b/Ministerie_Base.py
@@ -1,0 +1,215 @@
+import sys
+import os
+import random
+import names
+import pandas as pd
+import world_bank_data as wb
+from PyQt5.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel,
+    QTableWidget, QTableWidgetItem, QHeaderView, QFrame, QPushButton, QFileDialog
+)
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QPixmap
+
+# Globale variabele gedeeld tussen ministeries om een gekozen landnaam te onthouden
+global_translated_country_name = None
+
+
+class MinisterieBaseApp(QWidget):
+    """Basisklasse met gedeelde functionaliteit voor alle ministeries."""
+    countries_df = None
+
+    def __init__(self, window_title: str, minister_label: str):
+        super().__init__()
+        self.window_title = window_title
+        self.minister_label_text = minister_label
+        self.initUI()
+
+    def initUI(self):
+        self.setWindowTitle(self.window_title)
+        self.setGeometry(100, 100, 1000, 600)
+
+        main_layout = QHBoxLayout(self)
+        left_layout = QVBoxLayout()
+
+        self.input_field = QLineEdit(self)
+        self.input_field.setPlaceholderText("Voer de naam van een land in")
+        self.input_field.returnPressed.connect(self.update_data)
+        left_layout.addWidget(self.input_field)
+
+        self.country_label = QLabel("Gekozen land: ", self)
+        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")
+        left_layout.addWidget(self.country_label)
+
+        self.table = QTableWidget(self)
+        self.table.setColumnCount(0)
+        self.table.setRowCount(0)
+        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
+        self.table.verticalHeader().setSectionResizeMode(QHeaderView.Interactive)
+        left_layout.addWidget(self.table)
+
+        self.save_button = QPushButton("Opslaan", self)
+        self.save_button.clicked.connect(self.manual_save_data)
+        left_layout.addWidget(self.save_button)
+
+        self.load_button = QPushButton("Laad een saved file", self)
+        self.load_button.clicked.connect(self.load_data_from_file)
+        left_layout.addWidget(self.load_button)
+
+        right_layout = QVBoxLayout()
+        self.image_label = QLabel(self)
+        self.image_label.setFixedSize(300, 300)
+        self.image_label.setFrameShape(QFrame.Box)
+        right_layout.addWidget(self.image_label, alignment=Qt.AlignCenter)
+
+        self.minister_label = QLabel(self.minister_label_text, self)
+        self.minister_label.setAlignment(Qt.AlignCenter)
+        right_layout.addWidget(self.minister_label)
+
+        self.name_label = QLabel("", self)
+        self.name_label.setAlignment(Qt.AlignCenter)
+        right_layout.addWidget(self.name_label)
+        right_layout.setSpacing(2)
+
+        main_layout.addLayout(left_layout)
+        main_layout.addLayout(right_layout)
+        self.setLayout(main_layout)
+
+        self.load_random_image_and_name()
+        self.minister_label.setStyleSheet("color: white;")
+        self.name_label.setStyleSheet("color: white;")
+
+    # ------------------------------------------------------------------
+    # Functionaliteit voor het opslaan en laden van tabellen
+    # ------------------------------------------------------------------
+    def manual_save_data(self):
+        try:
+            if self.table.rowCount() > 0:
+                filename, _ = QFileDialog.getSaveFileName(
+                    self, "Sla bestand op", "", "CSV Files (*.csv);;All Files (*)")
+                if filename:
+                    if not filename.endswith(".csv"):
+                        filename += ".csv"
+                    data = {
+                        self.table.horizontalHeaderItem(0).text(): [
+                            self.table.item(row, 0).text() for row in range(self.table.rowCount())
+                        ],
+                        self.table.horizontalHeaderItem(1).text(): [
+                            self.table.item(row, 1).text() for row in range(self.table.rowCount())
+                        ],
+                    }
+                    df = pd.DataFrame(data)
+                    df['Land'] = self.country_label.text().replace("Gekozen land: ", "")
+                    df.to_csv(filename, index=False)
+                    print(f"Data opgeslagen in {filename}")
+                else:
+                    print("Opslaan geannuleerd.")
+            else:
+                print("Geen data beschikbaar om op te slaan.")
+        except Exception as e:
+            print(f"Er is een fout opgetreden tijdens het opslaan: {str(e)}")
+
+    def load_data_from_file(self):
+        options = QFileDialog.Options()
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Kies een opgeslagen data bestand", "",
+            "CSV Files (*.csv);;All Files (*)", options=options)
+        if filename:
+            loaded_data = pd.read_csv(filename)
+            self.display_loaded_data(loaded_data)
+
+    def display_loaded_data(self, data: pd.DataFrame):
+        country_name = data.iloc[0]['Land']
+        self.country_label.setText(f"Gekozen land: {country_name}")
+        data = data.drop(columns=['Land'])
+        indicators = data.iloc[:, 0].tolist()
+        values = data.iloc[:, 1].tolist()
+
+        self.table.setColumnCount(2)
+        self.table.setRowCount(len(indicators))
+        self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
+
+        for i, indicator in enumerate(indicators):
+            indicator_item = QTableWidgetItem(indicator)
+            indicator_item.setTextAlignment(Qt.AlignCenter)
+            self.table.setItem(i, 0, indicator_item)
+            value_item = QTableWidgetItem(values[i])
+            value_item.setTextAlignment(Qt.AlignCenter)
+            self.table.setItem(i, 1, value_item)
+
+        self.table.resizeColumnsToContents()
+        self.table.resizeRowsToContents()
+        self.table.horizontalHeader().setStretchLastSection(False)
+        self.table.verticalHeader().setStretchLastSection(False)
+
+    # ------------------------------------------------------------------
+    # Gedeelde functionaliteit voor het tonen van data
+    # ------------------------------------------------------------------
+    def load_random_image_and_name(self):
+        image_folder = "gezichten"
+        images = [f for f in os.listdir(image_folder) if os.path.isfile(os.path.join(image_folder, f))]
+        if images:
+            random_image = random.choice(images)
+            pixmap = QPixmap(os.path.join(image_folder, random_image))
+            if pixmap.isNull():
+                self.image_label.setText("Afbeelding niet gevonden")
+            else:
+                self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), Qt.KeepAspectRatio))
+        else:
+            self.image_label.setText("Geen afbeeldingen gevonden in de map")
+        random_name = names.get_full_name()
+        self.name_label.setText(f"Uw minister heet: {random_name}")
+
+    def update_data(self):
+        global global_translated_country_name
+        country_name = global_translated_country_name if global_translated_country_name else self.input_field.text()
+        self.country_label.setText(f"Gekozen land: {country_name}")
+        country_data = self.get_country_indicators(country_name)
+        if country_data is not None:
+            indicators = list(country_data.columns)[2:]
+            values = [self.format_value(ind, country_data.iloc[0][ind]) for ind in indicators]
+            self.table.setColumnCount(2)
+            self.table.setRowCount(len(indicators))
+            self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
+            for i, indicator in enumerate(indicators):
+                indicator_item = QTableWidgetItem(indicator)
+                indicator_item.setTextAlignment(Qt.AlignCenter)
+                self.table.setItem(i, 0, indicator_item)
+                value_item = QTableWidgetItem(values[i])
+                value_item.setTextAlignment(Qt.AlignCenter)
+                self.table.setItem(i, 1, value_item)
+            self.table.resizeColumnsToContents()
+            self.table.resizeRowsToContents()
+            self.table.horizontalHeader().setStretchLastSection(False)
+            self.table.verticalHeader().setStretchLastSection(False)
+        else:
+            self.table.setColumnCount(0)
+            self.table.setRowCount(0)
+            self.table.setHorizontalHeaderLabels([])
+            self.table.clearContents()
+
+    def get_indicator_codes(self) -> dict:
+        """Geef een dict terug met indicator-naam als sleutel en WorldBank-code als waarde."""
+        return {}
+
+    def format_value(self, indicator: str, value) -> str:
+        """Formateer de waarde voor weergave in de tabel."""
+        if pd.isna(value):
+            return "N/A"
+        return str(value)
+
+    def get_country_indicators(self, country_name: str):
+        if MinisterieBaseApp.countries_df is None:
+            MinisterieBaseApp.countries_df = wb.get_countries()
+        indicators = self.get_indicator_codes()
+        if not indicators:
+            return None
+        data = {}
+        for name, code in indicators.items():
+            data[name] = wb.get_series(code, id_or_value='id', simplify_index=True, mrv=1)
+        df = MinisterieBaseApp.countries_df[['region', 'name']].rename(columns={'name': 'country'})
+        df = df.loc[df.region != 'Aggregates']
+        for name, series in data.items():
+            df[name] = series
+        country_data = df[df['country'].str.lower() == country_name.lower()]
+        return country_data if not country_data.empty else None

--- a/Ministerie_Van_Economische_Zaken.py
+++ b/Ministerie_Van_Economische_Zaken.py
@@ -1,248 +1,18 @@
 import sys
-import os
-import random
-import names
 import pandas as pd
-import world_bank_data as wb
-from PyQt5.QtWidgets import QApplication, QWidget, QVBoxLayout, QHBoxLayout, QLineEdit, QLabel, QTableWidget, \
-    QTableWidgetItem, QHeaderView, QFrame
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap
-import uuid
-from PyQt5.QtWidgets import QPushButton, QFileDialog
-
-# Globale variabele om de Engelse landnaam op te slaan
-global_translated_country_name = None
+from Ministerie_Base import MinisterieBaseApp
+from PyQt5.QtWidgets import QApplication
 
 
-class MinisterieVanEconomischeZakenApp(QWidget):
+class MinisterieVanEconomischeZakenApp(MinisterieBaseApp):
     def __init__(self):
-        super().__init__()
+        super().__init__(
+            'Ministerie van Economische Zaken',
+            'Dit is uw huidige minister van financiën'
+        )
 
-        self.initUI()
-
-    def initUI(self):
-        self.setWindowTitle('Ministerie van Economische Zaken')
-        self.setGeometry(100, 100, 1000, 600)
-
-        # Hoofd Layout
-        main_layout = QHBoxLayout(self)
-
-        # Layout voor de linkerkant (land informatie)
-        left_layout = QVBoxLayout()
-
-        # Input veld voor land
-        self.input_field = QLineEdit(self)
-        self.input_field.setPlaceholderText("Voer de naam van een land in")
-        self.input_field.returnPressed.connect(self.update_data)
-        left_layout.addWidget(self.input_field)
-
-        # Label voor gekozen land
-        self.country_label = QLabel("Gekozen land: ", self)
-        self.country_label.setStyleSheet("font-weight: bold; font-size: 11pt;")  # Maak de tekst dik en 2 maten groter
-        left_layout.addWidget(self.country_label)
-
-        # Tabel om de data weer te geven
-        self.table = QTableWidget(self)
-        self.table.setColumnCount(0)
-        self.table.setRowCount(0)
-
-        # Instellingen voor het aanpassen van rijen en kolommen
-        self.table.horizontalHeader().setSectionResizeMode(QHeaderView.Interactive)
-        self.table.verticalHeader().setSectionResizeMode(QHeaderView.Interactive)
-
-        left_layout.addWidget(self.table)
-
-        # Knop om data op te slaan
-        self.save_button = QPushButton("Opslaan", self)
-        self.save_button.clicked.connect(self.manual_save_data)
-        left_layout.addWidget(self.save_button)
-
-        # Knop om eerder opgeslagen data te laden
-        self.load_button = QPushButton("Laad een saved file", self)
-        self.load_button.clicked.connect(self.load_data_from_file)
-        left_layout.addWidget(self.load_button)
-
-        # Layout voor de rechterkant (minister afbeelding)
-        right_layout = QVBoxLayout()
-
-        # Afbeeldingslabel
-        self.image_label = QLabel(self)
-        self.image_label.setFixedSize(300, 300)  # Stel grootte van afbeelding in
-        self.image_label.setFrameShape(QFrame.Box)  # Voeg een kader rond de afbeelding toe
-        right_layout.addWidget(self.image_label, alignment=Qt.AlignCenter)
-
-        # Label voor tekst onder afbeelding
-        self.minister_label = QLabel("Dit is uw huidige minister van financiën", self)
-        self.minister_label.setAlignment(Qt.AlignCenter)
-        right_layout.addWidget(self.minister_label)
-
-        # Label voor de willekeurige naam
-        self.name_label = QLabel("", self)
-        self.name_label.setAlignment(Qt.AlignCenter)
-        right_layout.addWidget(self.name_label)
-
-        # Verklein de afstand tussen de labels
-        right_layout.setSpacing(2)
-
-        # Voeg layouts toe aan de hoofd layout
-        main_layout.addLayout(left_layout)
-        main_layout.addLayout(right_layout)
-
-        # Zet de layout op het hoofdvenster
-        self.setLayout(main_layout)
-
-        # Laad de afbeelding en naam bij het opstarten
-        self.load_random_image_and_name()
-
-        # Pas de stijl aan voor de tekstkleur
-        self.minister_label.setStyleSheet("color: white;")
-        self.name_label.setStyleSheet("color: white;")
-
-    def manual_save_data(self):
-        try:
-            if self.table.rowCount() > 0:
-                # Open een dialoogvenster om een bestandsnaam in te voeren
-                filename, _ = QFileDialog.getSaveFileName(self, "Sla bestand op", "",
-                                                          "CSV Files (*.csv);;All Files (*)")
-
-                if filename:
-                    if not filename.endswith(".csv"):
-                        filename += ".csv"
-
-                    # Maak een DataFrame van de huidige data in de tabel
-                    data = {
-                        self.table.horizontalHeaderItem(0).text(): [self.table.item(row, 0).text() for row in
-                                                                    range(self.table.rowCount())],
-                        self.table.horizontalHeaderItem(1).text(): [self.table.item(row, 1).text() for row in
-                                                                    range(self.table.rowCount())],
-                    }
-                    df = pd.DataFrame(data)
-
-                    # Voeg de landnaam als een extra kolom toe
-                    df['Land'] = self.country_label.text().replace("Gekozen land: ", "")
-
-                    # Sla de data op in het bestand met de door de gebruiker ingevoerde naam
-                    df.to_csv(filename, index=False)
-
-                    print(f"Data opgeslagen in {filename}")
-                else:
-                    print("Opslaan geannuleerd.")
-            else:
-                print("Geen data beschikbaar om op te slaan.")
-        except Exception as e:
-            print(f"Er is een fout opgetreden tijdens het opslaan: {str(e)}")
-
-    def load_data_from_file(self):
-        # Open een dialoogvenster om een bestand te kiezen
-        options = QFileDialog.Options()
-        filename, _ = QFileDialog.getOpenFileName(self, "Kies een opgeslagen data bestand", "",
-                                                  "CSV Files (*.csv);;All Files (*)", options=options)
-
-        if filename:
-            # Lees de data van het CSV-bestand
-            loaded_data = pd.read_csv(filename)
-
-            # Update de tabel met de geladen data
-            self.display_loaded_data(loaded_data)
-
-    def display_loaded_data(self, data):
-        # Haal de landnaam op uit de laatste kolom
-        country_name = data.iloc[0]['Land']
-        self.country_label.setText(f"Gekozen land: {country_name}")
-
-        # Verwijder de landnaam kolom voordat je de rest van de data in de tabel zet
-        data = data.drop(columns=['Land'])
-
-        indicators = data.iloc[:, 0].tolist()  # Eerste kolom
-        values = data.iloc[:, 1].tolist()  # Tweede kolom
-
-        self.table.setColumnCount(2)
-        self.table.setRowCount(len(indicators))
-
-        self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
-
-        for i, indicator in enumerate(indicators):
-            indicator_item = QTableWidgetItem(indicator)
-            indicator_item.setTextAlignment(Qt.AlignCenter)
-            self.table.setItem(i, 0, indicator_item)
-
-            value_item = QTableWidgetItem(values[i])
-            value_item.setTextAlignment(Qt.AlignCenter)
-            self.table.setItem(i, 1, value_item)
-
-        self.table.resizeColumnsToContents()
-        self.table.resizeRowsToContents()
-
-        self.table.horizontalHeader().setStretchLastSection(False)
-        self.table.verticalHeader().setStretchLastSection(False)
-
-    def update_data(self):
-        global global_translated_country_name  # Gebruik de globale variabele
-
-        # Gebruik de globale variabele als deze beschikbaar is, anders gebruik de ingevoerde naam
-        country_name = global_translated_country_name if global_translated_country_name else self.input_field.text()
-        self.country_label.setText(f"Gekozen land: {country_name}")
-
-        country_data = self.get_country_economic_indicators(country_name)
-
-        if country_data is not None:
-            # In plaats van kolommen, maken we nu één kolom voor de indicatoren en één voor de waarden
-            indicators = list(country_data.columns)[2:]  # Sla de eerste twee kolommen over ('region', 'country')
-            values = [self.format_value(indicator, country_data.iloc[0][indicator]) for indicator in indicators]
-
-            self.table.setColumnCount(2)  # Eén kolom voor indicatoren, één voor waarden
-            self.table.setRowCount(len(indicators))
-
-            self.table.setHorizontalHeaderLabels(['Indicator', 'Waarde'])
-
-            for i, indicator in enumerate(indicators):
-                indicator_item = QTableWidgetItem(indicator)
-                indicator_item.setTextAlignment(Qt.AlignCenter)
-                self.table.setItem(i, 0, indicator_item)
-
-                value_item = QTableWidgetItem(values[i])
-                value_item.setTextAlignment(Qt.AlignCenter)
-                self.table.setItem(i, 1, value_item)
-
-            # Zorg ervoor dat de cellen zich aanpassen aan de inhoud
-            self.table.resizeColumnsToContents()
-            self.table.resizeRowsToContents()
-
-            # De tabel headers kunnen nog steeds handmatig worden aangepast
-            self.table.horizontalHeader().setStretchLastSection(False)
-            self.table.verticalHeader().setStretchLastSection(False)
-        else:
-            self.table.setColumnCount(0)
-            self.table.setRowCount(0)
-            self.table.setHorizontalHeaderLabels([])
-            self.table.clearContents()
-
-    def load_random_image_and_name(self):
-        # Kies een willekeurige afbeelding uit de map "gezichten"
-        image_folder = "gezichten"
-        images = [f for f in os.listdir(image_folder) if os.path.isfile(os.path.join(image_folder, f))]
-
-        if images:
-            random_image = random.choice(images)
-            pixmap = QPixmap(os.path.join(image_folder, random_image))
-
-            if pixmap.isNull():
-                self.image_label.setText("Afbeelding niet gevonden")
-            else:
-                self.image_label.setPixmap(pixmap.scaled(self.image_label.size(), Qt.KeepAspectRatio))
-        else:
-            self.image_label.setText("Geen afbeeldingen gevonden in de map")
-
-        # Genereer een willekeurige naam en zet de tekst met de naam direct onder de minister_label
-        random_name = names.get_full_name()
-        self.name_label.setText(f"Uw minister heet: {random_name}")
-
-    def get_country_economic_indicators(self, country_name):
-        # Data ophalen van de Wereldbank
-        countries = wb.get_countries()
-
-        indicators = {
+    def get_indicator_codes(self) -> dict:
+        return {
             'BBP (totaal)': 'NY.GDP.MKTP.CD',
             'Bevolking': 'SP.POP.TOTL',
             'BBP per Hoofd van de Bevolking': 'NY.GDP.PCAP.CD',
@@ -257,43 +27,24 @@ class MinisterieVanEconomischeZakenApp(QWidget):
             'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)': 'SL.IND.EMPL.ZS',
             'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)': 'SL.SRV.EMPL.ZS',
             'Buitenlandse Directe Investeringen (% van BBP)': 'BX.KLT.DINV.WD.GD.ZS',
-            'Totale Reserves (inclusief Goud, Huidige US$)': 'FI.RES.TOTL.CD',
+            'Totale Reserves (inclusief Goud, Huidige US$)': 'FI.RES.TOTL.CD'
         }
 
-        data = {}
-        for name, code in indicators.items():
-            data[name] = wb.get_series(code, id_or_value='id', simplify_index=True, mrv=1)
-
-        df = countries[['region', 'name']].rename(columns={'name': 'country'}).loc[countries.region != 'Aggregates']
-
-        for name, series in data.items():
-            df[name] = series
-
-        country_data = df[df['country'].str.lower() == country_name.lower()]
-
-        if not country_data.empty:
-            return country_data
-        else:
-            return None
-
-    def format_value(self, indicator, value):
+    def format_value(self, indicator: str, value) -> str:
         if pd.isna(value):
             return "N/A"
-
         if indicator in ['BBP (totaal)', 'BBP per Hoofd van de Bevolking']:
             return f"€{value:,.2f}"
-        elif indicator in ['Bevolking']:
+        elif indicator == 'Bevolking':
             return f"{value:,.0f}"
-        elif indicator in ['Inflatie (CPI)',
-                           'Werkloosheid',
-                           'Overheidsuitgaven aan Onderwijs (% van BBP)',
-                           'Stedelijke Bevolking (%)',
-                           'Handelsbalans (% van BBP)',
-                           'High-tech Export (% van Totale Export)',
-                           'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)',
-                           'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)',
-                           'Buitenlandse Directe Investeringen (% van BBP)']:
+        elif indicator in [
+            'Inflatie (CPI)', 'Werkloosheid', 'Stedelijke Bevolking (%)',
+            'Handelsbalans (% van BBP)', 'High-tech Export (% van Totale Export)',
+            'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)',
+            'Werkgelegenheid in Industrie (% van Totale Werkgelegenheid)',
+            'Werkgelegenheid in Diensten (% van Totale Werkgelegenheid)',
+            'Buitenlandse Directe Investeringen (% van BBP)'
+        ]:
             return f"{value:.2f}%"
         elif indicator == 'Levensverwachting':
             return f"{value:.2f} jaar"

--- a/Ministerie_Van_Huisvesting.py
+++ b/Ministerie_Van_Huisvesting.py
@@ -1,0 +1,34 @@
+import sys
+import pandas as pd
+from Ministerie_Base import MinisterieBaseApp
+from PyQt5.QtWidgets import QApplication
+
+
+class MinisterieVanHuisvestingApp(MinisterieBaseApp):
+    def __init__(self):
+        super().__init__(
+            'Ministerie van Huisvesting',
+            'Dit is uw huidige minister van huisvesting'
+        )
+
+    def get_indicator_codes(self) -> dict:
+        return {
+            'Bevolkingsdichtheid (per km²)': 'EN.POP.DNST',
+            'Stedelijke Bevolking (%)': 'SP.URB.TOTL.IN.ZS',
+            'Bevolking in Sloppenwijken (%)': 'EN.POP.SLUM.UR.ZS'
+        }
+
+    def format_value(self, indicator: str, value) -> str:
+        if pd.isna(value):
+            return "N/A"
+        if '(%' in indicator:
+            return f"{value:.2f}%"
+        else:
+            return f"{value:,.2f}"
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    main_app = MinisterieVanHuisvestingApp()
+    main_app.show()
+    sys.exit(app.exec_())

--- a/Ministerie_Van_Landbouw.py
+++ b/Ministerie_Van_Landbouw.py
@@ -1,0 +1,36 @@
+import sys
+import pandas as pd
+from Ministerie_Base import MinisterieBaseApp
+from PyQt5.QtWidgets import QApplication
+
+
+class MinisterieVanLandbouwApp(MinisterieBaseApp):
+    def __init__(self):
+        super().__init__(
+            'Ministerie van Landbouw',
+            'Dit is uw huidige minister van landbouw'
+        )
+
+    def get_indicator_codes(self) -> dict:
+        return {
+            'Landbouwgrond (km²)': 'AG.LND.AGRI.K2',
+            'Landbouw, Bosbouw en Visserij (% van BBP)': 'NV.AGR.TOTL.ZS',
+            'Werkgelegenheid in Landbouw (% van Totale Werkgelegenheid)': 'SL.AGR.EMPL.ZS'
+        }
+
+    def format_value(self, indicator: str, value) -> str:
+        if pd.isna(value):
+            return "N/A"
+        if '(%' in indicator:
+            return f"{value:.2f}%"
+        elif 'km²' in indicator:
+            return f"{value:,.0f}"
+        else:
+            return f"{value:,.2f}"
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    main_app = MinisterieVanLandbouwApp()
+    main_app.show()
+    sys.exit(app.exec_())

--- a/Ministerie_Van_Leger.py
+++ b/Ministerie_Van_Leger.py
@@ -1,0 +1,36 @@
+import sys
+import pandas as pd
+from Ministerie_Base import MinisterieBaseApp
+from PyQt5.QtWidgets import QApplication
+
+
+class MinisterieVanLegerApp(MinisterieBaseApp):
+    def __init__(self):
+        super().__init__(
+            'Ministerie van Defensie',
+            'Dit is uw huidige minister van defensie'
+        )
+
+    def get_indicator_codes(self) -> dict:
+        return {
+            'Militaire Uitgaven (US$)': 'MS.MIL.XPND.CD',
+            'Militaire Uitgaven (% van BBP)': 'MS.MIL.XPND.GD.ZS',
+            'Personeel in de Strijdkrachten': 'MS.MIL.TOTL.P1'
+        }
+
+    def format_value(self, indicator: str, value) -> str:
+        if pd.isna(value):
+            return "N/A"
+        if indicator.endswith('(US$)'):
+            return f"${value:,.2f}"
+        elif '(%' in indicator:
+            return f"{value:.2f}%"
+        else:
+            return f"{value:,.0f}"
+
+
+if __name__ == '__main__':
+    app = QApplication(sys.argv)
+    main_app = MinisterieVanLegerApp()
+    main_app.show()
+    sys.exit(app.exec_())

--- a/main.py
+++ b/main.py
@@ -5,6 +5,9 @@ from Country_Info import CountryInfoApp  # Zorg ervoor dat je deze klasse hebt g
 from Sunplot_GDP import WereldGDPApp  # Zorg ervoor dat je deze klasse hebt gedefinieerd
 from Sunplot_wereldpopulatie import WereldPopulatieApp  # Importeer de WereldPopulatieApp klasse
 from Ministerie_Van_Economische_Zaken import MinisterieVanEconomischeZakenApp  # Zorg ervoor dat je deze klasse hebt gedefinieerd
+from Ministerie_Van_Leger import MinisterieVanLegerApp
+from Ministerie_Van_Landbouw import MinisterieVanLandbouwApp
+from Ministerie_Van_Huisvesting import MinisterieVanHuisvestingApp
 from muziek import MuziekSpeler  # Zorg ervoor dat je deze klasse hebt gedefinieerd
 
 class MainApp(QMainWindow):
@@ -32,6 +35,15 @@ class MainApp(QMainWindow):
 
         ministerie_economische_zaken_app = MinisterieVanEconomischeZakenApp()
         tab_widget.addTab(ministerie_economische_zaken_app, "Economische Zaken")
+
+        ministerie_leger_app = MinisterieVanLegerApp()
+        tab_widget.addTab(ministerie_leger_app, "Leger")
+
+        ministerie_landbouw_app = MinisterieVanLandbouwApp()
+        tab_widget.addTab(ministerie_landbouw_app, "Landbouw")
+
+        ministerie_huisvesting_app = MinisterieVanHuisvestingApp()
+        tab_widget.addTab(ministerie_huisvesting_app, "Huisvesting")
 
         wereld_gdp_app = WereldGDPApp()
         tab_widget.addTab(wereld_gdp_app, "Wereld GDP")


### PR DESCRIPTION
## Summary
- introduce `Ministerie_Base` to share common UI and logic
- rewrite all ministry apps to inherit from the base class
- keep main program importing the new streamlined ministry modules

## Testing
- `python -m py_compile main.py Ministerie_Van_Economische_Zaken.py Ministerie_Van_Landbouw.py Ministerie_Van_Leger.py Ministerie_Van_Huisvesting.py Ministerie_Base.py`